### PR TITLE
Add steps MDX component

### DIFF
--- a/data/docs/2-components.mdx
+++ b/data/docs/2-components.mdx
@@ -93,3 +93,39 @@ import { twMerge } from 'tailwind-merge';
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 ```
+
+## Steps
+
+The `Steps` component renders a numbered set of steps, useful for displaying step-by-step instructions. It turns each `h3` heading within it into a step heading with a number.
+
+<Steps>
+### Do a thing
+
+This thing is very important! You should do it.
+
+### Do another thing
+
+This other thing is not as important as the first one, but you should do it anyway.
+
+### That's it lol
+
+There isn't really a third thing to do, I just felt like having three steps here is better.
+
+</Steps>
+
+```mdx
+<Steps>
+### Do a thing
+
+This thing is very important! You should do it.
+
+### Do another thing
+
+This other thing is not as important as the first one, but you should do it anyway.
+
+### That's it lol
+
+There isn't really a third thing to do, I just felt like having three steps here is better.
+
+</Steps>
+```

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -17,10 +17,12 @@ const Layout = ({ children }: PropsWithChildren) => {
 
       <div
         className={cn(
-          'relative mx-auto grid max-w-8xl grow grid-cols-1 pt-16 [--sidebar-width:theme(spacing.80)] xl:grid-cols-[1fr,var(--toc-width,0)] print:block print:grid-cols-1 print:p-0',
+          'relative mx-auto grid max-w-8xl grow grid-cols-1 pt-16 [--sidebar-width:theme(spacing.80)] [--toc-width:theme(spacing.72)] print:block print:grid-cols-1 print:p-0',
+          doc?.showSidebar && 'md:grid-cols-[var(--sidebar-width)_1fr]',
+          doc?.showToc && 'xl:grid-cols-[1fr,var(--toc-width)]',
           doc?.showSidebar &&
-            'md:grid-cols-[var(--sidebar-width,0)_1fr] xl:grid-cols-[var(--sidebar-width,0)_1fr,var(--toc-width,0)]',
-          doc?.showToc && '[--toc-width:theme(spacing.72)]'
+            doc.showToc &&
+            'xl:grid-cols-[var(--sidebar-width)_1fr,var(--toc-width,0)]'
         )}
       >
         <Sidebar />

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -17,9 +17,9 @@ const Layout = ({ children }: PropsWithChildren) => {
 
       <div
         className={cn(
-          'relative mx-auto grid max-w-8xl grow grid-cols-1 pt-16 xl:grid-cols-[1fr,var(--toc-width,0)] print:block print:grid-cols-1 print:p-0',
+          'relative mx-auto grid max-w-8xl grow grid-cols-1 pt-16 [--sidebar-width:theme(spacing.80)] xl:grid-cols-[1fr,var(--toc-width,0)] print:block print:grid-cols-1 print:p-0',
           doc?.showSidebar &&
-            'md:grid-cols-[theme(spacing.80)_1fr] xl:grid-cols-[theme(spacing.80)_1fr,var(--toc-width,0)]',
+            'md:grid-cols-[var(--sidebar-width,0)_1fr] xl:grid-cols-[var(--sidebar-width,0)_1fr,var(--toc-width,0)]',
           doc?.showToc && '[--toc-width:theme(spacing.72)]'
         )}
       >

--- a/src/components/layout/mdx/code-block.tsx
+++ b/src/components/layout/mdx/code-block.tsx
@@ -38,7 +38,7 @@ const CopyCodeButton = ({ codeRef, className }: CopyCodeButtonProps) => {
         icon
         variant='flat'
         size='sm'
-        className={cn('text-muted-foreground', className)}
+        className={cn('text-muted-foreground print:hidden', className)}
         onClick={handleCopy}
       >
         {justCopied ? <CheckIcon /> : <CopyIcon />}

--- a/src/components/layout/mdx/index.tsx
+++ b/src/components/layout/mdx/index.tsx
@@ -10,6 +10,7 @@ import type { Doc } from '@/types/docs';
 import { MdxBlockquote } from './blockquote';
 import { CodeBlock } from './code-block';
 import { h1, h2, h3, h4 } from './heading';
+import { Steps } from './steps';
 
 export const mdxComponents = {
   h1,
@@ -19,6 +20,7 @@ export const mdxComponents = {
   a: Link,
   blockquote: MdxBlockquote,
   pre: CodeBlock,
+  Steps,
 };
 
 export type MDXProps = { doc: Doc };

--- a/src/components/layout/mdx/index.tsx
+++ b/src/components/layout/mdx/index.tsx
@@ -32,7 +32,7 @@ export const MDX = () => {
       className={cn(
         `prose mx-auto w-full max-w-[100vw] px-4 py-8 [print-color-adjust:exact] dark:prose-invert print:max-w-none print:px-0`,
         doc?.showSidebar &&
-          'md:max-w-[calc(100vw-22rem)] lg:max-w-[min(calc(100vw-22rem),theme(maxWidth.3xl))]',
+          'col-start-2 md:max-w-[calc(100vw-22rem)] lg:max-w-[min(calc(100vw-22rem),theme(maxWidth.3xl))]',
         doc?.showSidebar &&
           doc?.showToc &&
           'lg:max-w-[min(calc(100vw-22rem),theme(maxWidth.2xl))]'

--- a/src/components/layout/mdx/steps.tsx
+++ b/src/components/layout/mdx/steps.tsx
@@ -1,0 +1,19 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const Steps = ({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    {...props}
+    className={cn(
+      'relative mb-12 ml-4 border-l pl-8 [counter-reset:step] [&>h3]:[counter-increment:step] before:[&>h3]:absolute before:[&>h3]:ml-[-50px] before:[&>h3]:mt-[-4px] before:[&>h3]:inline-flex before:[&>h3]:size-9 before:[&>h3]:items-center before:[&>h3]:justify-center before:[&>h3]:rounded-full before:[&>h3]:border-4 before:[&>h3]:border-background before:[&>h3]:bg-card before:[&>h3]:text-center before:[&>h3]:-indent-px before:[&>h3]:text-base before:[&>h3]:font-medium before:[&>h3]:text-foreground before:[&>h3]:content-[counter(step)]',
+      className
+    )}
+  >
+    {children}
+  </div>
+);

--- a/src/components/layout/sidebar/sidebar.tsx
+++ b/src/components/layout/sidebar/sidebar.tsx
@@ -113,8 +113,8 @@ export const Sidebar = () => {
   return (
     <>
       {doc?.showSidebar && (
-        <aside className='sticky top-16 z-10 hidden select-none flex-col self-start after:absolute after:-top-16 after:end-0 after:-z-10 after:h-screen after:w-screen after:bg-card md:flex print:hidden [&_[data-sidebar-subheader]]:bg-card'>
-          <ScrollArea className='flex max-h-[calc(100dvh-4rem)] flex-col gap-px overflow-y-auto rounded-lg'>
+        <aside className='fixed top-0 z-10 hidden w-[--sidebar-width] select-none flex-col self-start after:absolute after:end-0 after:top-0 after:-z-10 after:h-screen after:w-screen after:bg-card md:flex print:hidden [&_[data-sidebar-subheader]]:bg-card'>
+          <ScrollArea className='mt-16 flex max-h-[calc(100dvh-4rem)] flex-col gap-px overflow-y-auto rounded-lg'>
             <List className='px-2 pb-2'>
               <ListCategories />
             </List>

--- a/src/components/layout/toc/index.tsx
+++ b/src/components/layout/toc/index.tsx
@@ -39,7 +39,7 @@ export const Toc = () => {
   );
 
   return (
-    <div className='sticky top-24 hidden self-start pe-8 ps-4 xl:block print:hidden'>
+    <div className='sticky top-24 mt-8 hidden self-start pe-8 ps-4 xl:block print:hidden'>
       <h3 className='mb-4 font-bold'>On this page</h3>
       <ul
         className='space-y-2 text-sm'


### PR DESCRIPTION
Add `<Steps>` component that turns `h3` headings within it into a list of numbered steps.

Other changes include:

- Fix code block copy button visible in print
- Fix incorrect sidebar BG & TOC scrolling behavior when overscrolling up (affects Firefox, and maybe Safari but untested)