### PR TITLE
Add description field to docs

### DIFF
--- a/data/docs/1-basic-usage.mdx
+++ b/data/docs/1-basic-usage.mdx
@@ -10,6 +10,7 @@ Pages in this docs site are located in the `data/` directory. Each page is an `.
 Each page has some frontmatter metadata at the top, which includes information about the page. The following properties can be included:
 
 - `title` - The title of the page. **Docs without a title will never be shown in the sidebar or search.**
+- `description` - A short description of the page, which will appear below the title.
 - `category` - Optional ID of the category this page belongs to. If not defined, the page is uncategorized. [More info](/docs/categories)
 - `showTitle` - Whether or not to show the page's title at its top. By default it's `true`.
 - `showToc` - Whether or not to show the page's table of contents on the side. By default it's `true`.

--- a/data/docs/2-components.mdx
+++ b/data/docs/2-components.mdx
@@ -106,6 +106,13 @@ const Counter = () => {
 
 You can also add a title to a code block, such as a file name.
 
+```ts title="lib/utils.ts"
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+```
+
 ````mdx
 ```ts title="lib/utils.ts"
 import { type ClassValue, clsx } from 'clsx';
@@ -114,15 +121,6 @@ import { twMerge } from 'tailwind-merge';
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 ```
 ````
-
-This would render:
-
-```ts title="lib/utils.ts"
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
-```
 
 ## Steps
 

--- a/data/docs/2-components.mdx
+++ b/data/docs/2-components.mdx
@@ -1,9 +1,8 @@
 ---
 title: Components & syntax
+description: Custom components you can use in MDX pages.
 category: usage
 ---
-
-The following components are available out of the box for use in MDX pages:
 
 ## Alerts
 

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -14,9 +14,10 @@ export const generateMetadata = async ({
 }) => {
   const slug = (await params).slug || [];
   const doc = allDocs.find(doc => doc.url === `/${slug.join('/')}`);
+  if (!doc) return {};
 
-  if (!doc?.title) return {};
-  return { title: doc.title };
+  const { title, description } = doc;
+  return { title, description };
 };
 
 const DocPage = async ({ params }: { params: Promise<{ slug: string[] }> }) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,12 @@ import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 
+export const generateMetadata = () => ({
+  description: 'A simple docs site powered by Next.js and Content Collections.',
+});
+
 const actions = [
-  { text: 'Get started', href: '/docs/basic-usage', primary: true },
+  { text: 'Get started', href: '/docs/getting-started', primary: true },
   { text: 'Sample pages', href: '/sample/markdown-test' },
 ] satisfies { text: string; href: string; primary?: boolean }[];
 

--- a/src/components/mdx/code-block.tsx
+++ b/src/components/mdx/code-block.tsx
@@ -65,8 +65,10 @@ export const CodeBlock = ({
   return (
     <div className='relative'>
       {title ? (
-        <div className='flex h-10 flex-row items-center rounded-t-lg border-b bg-[--tw-prose-pre-bg] pe-2 ps-4 font-mono text-sm text-muted-foreground'>
-          {title}
+        <div className='flex h-10 flex-row items-center rounded-t-lg border-b bg-[--tw-prose-pre-bg] pe-2 ps-4'>
+          <span className='font-mono text-sm text-muted-foreground'>
+            {title}
+          </span>
           <CopyCodeButton codeRef={preRef} className='ms-auto' />
         </div>
       ) : (

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -44,10 +44,18 @@ export const MDX = () => {
           'lg:max-w-[min(calc(100vw-22rem),theme(maxWidth.2xl))]'
       )}
     >
-      {doc?.title && doc?.showTitle && (
-        <h1 className='text-5xl font-extrabold tracking-tight sm:text-6xl'>
-          {doc?.title}
-        </h1>
+      {doc?.showTitle && (
+        <>
+          {doc.title && (
+            <h1 className='mb-14 text-5xl font-extrabold tracking-tight sm:text-6xl'>
+              {doc.title}
+            </h1>
+          )}
+          {doc.description && (
+            /* eslint-disable-next-line tailwindcss/no-custom-classname */
+            <p className='lead -mt-8 mb-14'>{doc.description}</p>
+          )}
+        </>
       )}
       <MDXContent code={doc?.body.code || ''} components={mdxComponents} />
     </main>

--- a/src/config/content-collections/doc.ts
+++ b/src/config/content-collections/doc.ts
@@ -21,7 +21,7 @@ export const doc = defineCollection({
     description: z.optional(z.string()),
     /** ID of the category this page belongs to. */
     category: z.optional(z.string()),
-    /** Whether or not to show the page's title at its top. */
+    /** Whether or not to show the page's title and description at its top. */
     showTitle: z.boolean().default(true),
     /** Whether or not to show the page's table of contents on the side. */
     showToc: z.boolean().default(true),

--- a/src/config/content-collections/doc.ts
+++ b/src/config/content-collections/doc.ts
@@ -17,6 +17,8 @@ export const doc = defineCollection({
   schema: z => ({
     /** Title of this page. */
     title: z.optional(z.string()),
+    /** Short description of this page, will appear below the title. */
+    description: z.optional(z.string()),
     /** ID of the category this page belongs to. */
     category: z.optional(z.string()),
     /** Whether or not to show the page's title at its top. */


### PR DESCRIPTION
Add a `description` field to docs, which adds a description below the title as well as in the `<head>` of the page; Update `showTitle` prop so it also hides the description if it's set to `false`.

Also included:

- Add description to home page (metadata)
- Fix mono font in codeblock copy button tooltip